### PR TITLE
add テーブルに罫線をつけた

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,11 @@
  *= require_tree .
  *= require_self
  */
+
+th, td {
+  border: solid 1px;
+}
+
+table {
+  border-collapse: collapse;
+}


### PR DESCRIPTION
費用の一覧をテーブル表示しているが、罫線がないと内容が見づらいため、罫線を表示するようにした。
罫線はCSSにて実現させた。